### PR TITLE
Add Ratio component.

### DIFF
--- a/dist/components/_ratio.scss
+++ b/dist/components/_ratio.scss
@@ -3,10 +3,11 @@
 // Fluid element with an intrinsic width/height ratio.
 //
 // 1. The aspect-ratio hack is applied to a pseudo-element because it allows
-//    the component to accept padding and respect `min/max-height`.
+//    the component to accept `min/max-height`.
+// 2. The ratio is 1 × 1 by default.
 //
 // Markup:
-// <div class="c-ratio c--1by1">
+// <div class="c-ratio c--4by3">
 //     <div class="c-ratio__item"></div>
 // </div>
 //
@@ -19,11 +20,12 @@
     display: block;
     overflow: hidden;
 
-    // 1
-    &::before {
+
+    &::before { // 1
         content: '';
         display: block;
         width: 100%;
+        padding-bottom: 100%; // 2
     }
 }
 
@@ -41,13 +43,6 @@
     left: 0;
     width: 100%;
     height: 100%;
-}
-
-
-// 1 × 1 Ratio
-
-.c-ratio.c--1by1::before {
-    padding-bottom: 100%;
 }
 
 

--- a/test/components/ratio/index.html
+++ b/test/components/ratio/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ratio Component Tests · Stencil</title>
+    <link rel="stylesheet" href="../../fixture.css">
+
+    <link rel="stylesheet" href="ratio.css">
+    <style>
+        .u-margin-above-m {
+            margin-top: 1.4rem;
+        }
+
+        .c-ratio.c--max-height {
+            max-height: 300px;
+        }
+    </style>
+</head>
+<body>
+    <h1 class="c-fixture-title">
+        <a class="c-fixture-title__sub" href="https://github.com/mobify/stencil">Stencil</a>
+        <div>Ratio Component Tests</div>
+    </h1>
+
+    <article class="c-test">
+        <h2 class="c-test__describe">.c-ratio</h2>
+
+        <div class="c-test__case">
+            <p class="c-test__should">It should be fluid-width, but constrained to a width:height ratio of 1:1.</p>
+            <div class="c-test__run">
+
+                <div class="c-ratio">
+                    <div class="c-ratio__item c-fixture-box"></div>
+                </div>
+
+            </div>
+        </div>
+
+        <div class="c-test__case">
+            <p class="c-test__should">It work automatically with children that are <code>&lt;iframe&gt;</code>, <code>&lt;object&gt;</code> or <code>&lt;embed&gt;</code>.</p>
+            <div class="c-test__run">
+
+                <div class="c-ratio">
+                    <iframe src="http://mobify.com" width="320px" height="480px"></iframe>
+                </div>
+
+                <div class="c-ratio u-margin-above-m">
+                    <object type="image/svg+xml" data="../../fixture.svg">Hello World from an SVG file!</object>
+                </div>
+
+            </div>
+        </div>
+
+        <div class="c-test__case">
+            <p class="c-test__should">It should support max-height.</p>
+            <div class="c-test__run">
+
+                <div class="c-ratio c--max-height">
+                    <div class="c-ratio__item c-fixture-box"></div>
+                </div>
+
+            </div>
+        </div>
+    </article>
+
+    <article class="c-test">
+        <h2 class="c-test__describe">.c-ratio.c--4by3</h2>
+
+        <div class="c-test__case">
+            <p class="c-test__should">It should render width a width:height ratio of 4:3 (SD video).</p>
+            <div class="c-test__run">
+
+                <div class="c-ratio c--4by3">
+                    <div class="c-ratio__item c-fixture-box"></div>
+                </div>
+
+            </div>
+        </div>
+    </article>
+
+    <article class="c-test">
+        <h2 class="c-test__describe">.c-ratio.c--16by9</h2>
+
+        <div class="c-test__case">
+            <p class="c-test__should">It should render width a width:height ratio of 16:9 (HD video).</p>
+            <div class="c-test__run">
+
+                <div class="c-ratio c--16by9">
+                    <div class="c-ratio__item c-fixture-box"></div>
+                </div>
+
+            </div>
+        </div>
+    </article>
+</body>
+</html>

--- a/test/components/ratio/ratio.scss
+++ b/test/components/ratio/ratio.scss
@@ -1,0 +1,2 @@
+
+@import '../../../dist/components/ratio';

--- a/test/fixture.svg
+++ b/test/fixture.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+
+<svg version="1.1" 
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="200" height="300"
+     style="background-color: #D2B48C;"
+     onload="loaded()">
+  <script type="text/javascript"><![CDATA[
+      function loaded() {
+        // change onloadFunc to point to your real onload function that you
+        // want called when the page is truly ready
+        var onloadFunc = doload;
+        
+        if (top.svgweb) {
+          top.svgweb.addOnLoad(onloadFunc, true, window);
+        } else {
+          onloadFunc();
+        }
+      }   
+      
+     function doload() {
+        // developers original onload handler
+        
+        // add an event listener to our circle; on* style events added right
+        // to the markup are not yet supported
+        var circle = document.getElementById('myCircle');
+        circle.addEventListener('mousedown', function(evt) {
+          alert('You pressed the mouse button on our circle: ' + evt.target.id);
+        }, false);
+     }
+  ]]></script>
+  <g id="myGroup" 
+     fill="blue" 
+     style="font-size: 18px; text-anchor: middle; font-family: serif;">
+    <circle id="myCircle"
+            cx="100" cy="75" r="50"
+            stroke="firebrick"
+            stroke-width="3" />
+    <text x="100" y="155">Hello World</text>
+    <text x="100" y="175">From An SVG File!</text>
+  </g>
+</svg>


### PR DESCRIPTION
Add component for easily constraining fluid elements to a particular aspect ratio. Most useful for things [like video](http://alistapart.com/article/creating-intrinsic-ratios-for-video/), the pattern can be useful in other situations as well.

Status: **Opened for visibility**
Reviewers: @kpeatt @jeffkamo @scalvert
## Changes
- Add ratio component.
## Notes
- Needs tests.
