### PR TITLE
Minor Grid Fix

### DIFF
--- a/dist/components/grid/_grid.scss
+++ b/dist/components/grid/_grid.scss
@@ -9,7 +9,7 @@ $grid-gutter: if( variable-exists(grid-gutter), $grid-gutter, $v-space );
 // For asymmetrical grids, add modifiers to grid spans.
 //
 // Markup:
-// <div class="c-grid c--{n}-up">
+// <div class="c-grid c--{n}up">
 //     <div class="c-grid__span">
 //     <div class="c-grid__span">
 //     <div class="c-grid__span">


### PR DESCRIPTION
Fix _grid.scss comment to reflect how the c--{n}up class is actually written.

Status: **Opened for visibility**
Reviewers: @kpeatt @ry5n 
## Changes
- Fix a comment reference to a class. The comment had referenced `c--{n}-up` when the actual class is written `c--{n}up`
