### PR TITLE
Button component – Fix text alignment bug.

### DIFF
--- a/dist/components/button/_button.scss
+++ b/dist/components/button/_button.scss
@@ -13,45 +13,38 @@ $button-font-size: inherit !default;
 //
 // Markup:
 // <button class="c-button" type="[button|submit]">{buttonText}</button>
-// <input class="c-button" type="submit" value="{Input element}">
-// <a class="c-button" href="{url}">{buttonText}</a>
+// <input class="c-button" type="submit" value="{submitText}">
+// <a class="c-button" href="{url}">{linkText}</a>
 //
 // Notes:
-// 1. Ensure consistent vertical alignment in modern browsers.
-// 2. Inherit font styles from ancestor.
-// 3. Normalize `line-height` (for `input`, it can't be changed from `normal`
+// 1. Inherit font styles from ancestor.
+// 2. Normalize `line-height` (for `input`, it can't be changed from `normal`
 //    in Firefox 4+).
-// 4. Vertically center contents regardless of padding.
-// 5. Ensure button text can wrap (`input` defaults to `pre`).
-// 6. Prevent button text from being selectable.
-// 7. Corrects inability to style tappable `input` types in iOS.
-// 8. Inherit font color from ancestor for all states
+// 3. Ensure button text can wrap (`input` defaults to `pre`).
+// 4. Prevent button text from being selectable.
+// 5. Corrects inability to style tappable `input` types in iOS.
+// 6. Inherit font color from ancestor for all states
 //
 // N.B. “Disabled” state for links must be managed in JavaScript.
 
 .c-button {
-    display: inline-block; // 1
-    display: inline-flex; // 1
+    display: inline-block;
     margin: 0;
     padding: $button-padding;
     border: $button-border;
     background: none;
-    font-family: $button-font-family; // 2
-    font-size: $button-font-size; // 2
-    line-height: normal; // 3
+    font-family: $button-font-family; // 1
+    font-size: $button-font-size; // 1
+    line-height: normal; // 2
     text-align: center;
-    align-items: center; // 4
-    white-space: normal; // 5
-    user-select: none; // 6
-    -webkit-appearance: none; // 7
-
-
-    // States
+    white-space: normal; // 3
+    user-select: none; // 4
+    -webkit-appearance: none; // 5
 
     &,
     &:focus,
     &:active {
-        color: $button-font-color;
+        color: $button-font-color; // 6
         text-decoration: none;
     }
 


### PR DESCRIPTION
(brief description / PR title)

Status: **Ready to merge**

Reviewers: **(GitHub @<name>s of all reviewers)**
Ticket: Fixes #26
## Changes
- Removes flexbox properties from button component. Note that this causes vertical alignment to differ between input, button and anchor elements only when the text within the button wraps. In this case, the solution is to apply `vertical-align: middle`. However, in the common case of non-wrapping button text the preferred alignment is baseline, so this remains the default.
- Update comments.
## How to test-drive this PR
- Run `grunt` and open tests/components/button/index.html
