### PR TITLE
Button component – Normalize border-radius across element types in iOS

### DIFF
--- a/dist/components/button/_button.scss
+++ b/dist/components/button/_button.scss
@@ -1,6 +1,7 @@
 
 $button-padding: 0.5rem 0.75rem !default;
-$button-border: 1px solid hsl(0, 0%, 80%) !default;
+$button-border: if( variable-exists(border), $border, 1px solid hsl(0, 0%, 80%) ) !default;
+$button-border-radius: if( variable-exists(border-radius), $border-radius, 0 ) !default;
 $button-font-color: inherit !default;
 $button-font-family: inherit !default;
 $button-font-size: inherit !default;
@@ -33,7 +34,7 @@ $button-font-size: inherit !default;
     margin: 0;
     padding: $button-padding;
     border: $button-border;
-    border-radius: 0; // 1
+    border-radius: $button-border-radius; // 1
     background: none;
     font-family: $button-font-family; // 2
     font-size: $button-font-size; // 2


### PR DESCRIPTION
In iOS, by default `<input>` elements have a small border-radius while `<button>` and `<a>` do not. This makes the border-radius 0 for all types.

Status: **Once #32 is merged, ready**

Reviewers: @kpeatt @jeffkamo
## Changes
- Sets border-radius to zero for all button components. Value can be overridden on a project basis.
## How to test-drive this PR
- Run `grunt` and open `dist/components/button/index.html` in iOS
