### PR TITLE
Add Gruntfile to bower’s ignore list.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "node_modules",
     "bower_components",
     "package.json",
+    "Gruntfile.js",
     "tests",
     "test"
   ],


### PR DESCRIPTION
Stencil’s Gruntfile is used only for development. This PR adds it to the list of Bower’s ignore files so it isn’t included in the installed package when running `bower install`. Fixes #37 .

Status: **Ready to merge**

Reviewers: @jeffkamo @kpeatt
## Changes
- Adds Gruntfile.js to Bower’s ignore list, so it won’t be included in the installed package.
