### PR TITLE
Improve browser support for dimension utils used with flexbox.

### DIFF
--- a/dist/utils/dimension/_dimension.scss
+++ b/dist/utils/dimension/_dimension.scss
@@ -51,9 +51,9 @@
 }
 
 
-// Ensure all `.u-width-` classes keep their explicit width 
+// Ensure all `.u-width-` classes keep their explicit width
 // when inside a flexbox, preventing them from growing or shrinking.
 
 [class*="u-width-"] {
-    flex: none !important;
+    flex: initial !important;
 }


### PR DESCRIPTION
When dimension utils are used on flex items, we need to ensure that their `flex-*` properties (grow, shrink, basis) are reset in order for the width specified by the util to take effect. Previously this was set with `flex: none` but this has issues in some older flexbox implementations. Using `flex: initial` solves the issue.

Status: **Ready to merge**

Reviewers: **@kpeatt, @jeffkamo **
Ticket: **fixes #50** 
Linked PRs: **N/A**
## Changes
- Change flexbox property reset from `flex: none` to `flex: initial`.
## Todo
- [ ] Add a test case
