### PR TITLE
Add Content component

### DIFF
--- a/dist/components/content/_content.scss
+++ b/dist/components/content/_content.scss
@@ -9,8 +9,8 @@
 // Configurable variables
 // ---
 
-$content-margin: if(variable-exists(h-space), round($h-space / 2), 1rem) !default;
-$content-max-width: none !default;
+$content__margin: if(variable-exists(h-space), round($h-space / 2), 1rem) !default;
+$content__max-width: none !default;
 
 
 // Content root
@@ -18,8 +18,8 @@ $content-max-width: none !default;
 
 .c-content {
     display: block;
-    padding-left: $content-margin;
-    padding-right: $content-margin;
+    padding-left: $content__margin;
+    padding-right: $content__margin;
 }
 
 
@@ -31,8 +31,8 @@ $content-max-width: none !default;
 
 .c-content__bleed {
     display: block;
-    margin-left: -$content-margin;
-    margin-right: -$content-margin;
+    margin-left: -$content__margin;
+    margin-right: -$content__margin;
 }
 
 
@@ -43,10 +43,10 @@ $content-max-width: none !default;
 // (line length) of text. Content is centered when the container exceeds the
 // maximum width.
 
-@if type-of($content-max-width) == number {
+@if type-of($content__max-width) == number {
     .c-content.c--capped {
         margin-left: auto;
         margin-right: auto;
-        max-width: $content-max-width;
+        max-width: $content__max-width;
     }
 }


### PR DESCRIPTION
Add a component for consistent horizontal margins on content. Also allows making descendant containers “full-bleed” by negating those  margins.

Status: **Opened for visibility**

Reviewers: *_@jeffkamo @kpeatt *_
## Changes
- Add content component
- NOTE: this uses the namespaced variables proposed in #59 
## Todo
- [ ] Add tests
