### PR TITLE
Update Autoprefixer for iOS 6

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
         autoprefixer: {
             options: {
                 browsers: [
-                    'last 3 iOS versions',
+                    'iOS >= 6.0',
                     'Android 2.3',
                     'Android 4',
                     'last 2 Chrome versions'


### PR DESCRIPTION
Update Autoprefixer for iOS 6. This fixes some bugs with the Align component on iOS 6

Status: **Ready for review**

Reviewers: **@kpeatt**

Ticket: Fixes [#71](https://github.com/mobify/stencil/issues/71), [#72](https://github.com/mobify/stencil/issues/72), [#73](https://github.com/mobify/stencil/issues/73)
