### PR TITLE
Button Component - Fix alignment on buttons with wrapping text

### DIFF
--- a/tests/visual/components/button/index.html
+++ b/tests/visual/components/button/index.html
@@ -52,9 +52,9 @@
         <div class="c-test__case">
             <p class="c-test__should">It should allow button text to wrap.</p>
             <div class="c-test__run">
-                <button class="c-button u-fixture-cap-width" type="button">Long button element text</button>
-                <input class="c-button u-fixture-cap-width" type="submit" value="Long input element text">
-                <a class="c-button u-fixture-cap-width" href="#">Long anchor element text</a>
+                <p><button class="c-button u-fixture-cap-width" type="button">Long button element text</button></p>
+                <p><input class="c-button u-fixture-cap-width" type="submit" value="Long input element text"></p>
+                <p><a class="c-button u-fixture-cap-width" href="#">Long anchor element text</a></p>
             </div>
         </div>
 


### PR DESCRIPTION
Button Component - Fix alignment on buttons with wrapping text

Status: **Ready for review**

Reviewers: **@kpeatt @jeffkamo @ry5n**
Ticket: Fixes [#76](https://github.com/mobify/stencil/issues/76)
