### PR TITLE
Clear none as a fix to iOS8 iPhone5 floats issue

### DIFF
--- a/dist/components/grid/_grid.scss
+++ b/dist/components/grid/_grid.scss
@@ -42,7 +42,7 @@ $grid-gutter: if( variable-exists(grid-gutter), $grid-gutter, $v-space );
 
 @for $n from 2 through 6 {
     .c-grid.c--#{$n}up .c-grid__span {
-        clear: both;
+        clear: none;
         width: (100%/$n);
 
         &:nth-child(#{$n}n+1) {


### PR DESCRIPTION
I met this issue only on iOS8 iPhone5 in all places where grid was used on Carnival.
iPhone6 iOS8 works fine with this component.

Probably we don't need to make it as a component fix, but should explore the issue.
