### PR TITLE
Grid Component - fix for 2 col grid bug on 32bit iOS devices

### DIFF
--- a/dist/components/grid/_grid.scss
+++ b/dist/components/grid/_grid.scss
@@ -54,7 +54,7 @@ $grid__v-gutter: if( variable-exists(v-space), $v-space, 10px ) !default;
     .c-grid.c--#{$n}up .c-grid__span {
         width: (100%/$n);
 
-        &:nth-child(#{$n}n+1) {
+        &:nth-of-type(#{$n}n+1) {
             clear: both;
         }
     }

--- a/tests/visual/components/grid/grid.css
+++ b/tests/visual/components/grid/grid.css
@@ -330,35 +330,35 @@ th {
 .c-grid.c--2up .c-grid__span {
   width: 50%;
 }
-.c-grid.c--2up .c-grid__span:nth-child(2n+1) {
+.c-grid.c--2up .c-grid__span:nth-of-type(2n+1) {
   clear: both;
 }
 
 .c-grid.c--3up .c-grid__span {
   width: 33.33333%;
 }
-.c-grid.c--3up .c-grid__span:nth-child(3n+1) {
+.c-grid.c--3up .c-grid__span:nth-of-type(3n+1) {
   clear: both;
 }
 
 .c-grid.c--4up .c-grid__span {
   width: 25%;
 }
-.c-grid.c--4up .c-grid__span:nth-child(4n+1) {
+.c-grid.c--4up .c-grid__span:nth-of-type(4n+1) {
   clear: both;
 }
 
 .c-grid.c--5up .c-grid__span {
   width: 20%;
 }
-.c-grid.c--5up .c-grid__span:nth-child(5n+1) {
+.c-grid.c--5up .c-grid__span:nth-of-type(5n+1) {
   clear: both;
 }
 
 .c-grid.c--6up .c-grid__span {
   width: 16.66667%;
 }
-.c-grid.c--6up .c-grid__span:nth-child(6n+1) {
+.c-grid.c--6up .c-grid__span:nth-of-type(6n+1) {
   clear: both;
 }
 


### PR DESCRIPTION
Fix for 2 column grids not displaying properly on 32bit iOS devices

Status: **Ready to merge**

Reviewers: **@jeffkamo @ry5n @nastiatikk @cole-sanderson @mlworks @kpeatt**

## Changes
- changed `nth-child` to `nth-of-type`