### PR TITLE
Fix legacy flexbox inheritance issue

### DIFF
--- a/dist/components/arrange/_arrange.scss
+++ b/dist/components/arrange/_arrange.scss
@@ -28,14 +28,16 @@ $arrange__h-gutter: if( variable-exists(h-space), $h-space, 21px ) !default;
 // ---
 //
 // 1. Remove default styles present on common root elements.
+// 2. Ensure in iOS 5 and 6 that flex-direction isn't inherited from
+//    any flexbox parents that has flex-direction set to row-reverse
 
 .c-arrange {
     display: flex;
-    flex-direction: row;
-    margin: 0;
-    padding: 0;
+    flex-direction: row; // 2
+    margin: 0; // 1
+    padding: 0; // 1
 
-    list-style: none;
+    list-style: none; // 1
 }
 
 
@@ -116,6 +118,15 @@ $arrange__h-gutter: if( variable-exists(h-space), $h-space, 21px ) !default;
 .c-arrange__item.c--order-4 { order: 4; }
 .c-arrange__item.c--order-5 { order: 5; }
 .c-arrange__item.c--order-6 { order: 6; }
+
+
+// Item modifiers: flex direction
+// ---
+//
+
+.c-arrange.c--row-reverse {
+    flex-direction: row-reverse;
+}
 
 
 // Modifier: gutters

--- a/dist/components/arrange/_arrange.scss
+++ b/dist/components/arrange/_arrange.scss
@@ -31,6 +31,7 @@ $arrange__h-gutter: if( variable-exists(h-space), $h-space, 21px ) !default;
 
 .c-arrange {
     display: flex;
+    flex-direction: row;
     margin: 0;
     padding: 0;
 

--- a/tests/visual/components/arrange/index.html
+++ b/tests/visual/components/arrange/index.html
@@ -69,6 +69,33 @@
 
             </div>
         </div>
+
+        <div class="c-test__case">
+            <p class="c-test__should">Nested arrange should not inherit flex-direction row-reverse from parents</p>
+            <div class="c-test__run">
+
+                <div class="c-arrange c--row-reverse">
+                    <div class="c-arrange__item c-fixture-box">
+                        1
+                        <div class="c-arrange">
+                            <div class="c-arrange__item c-fixture-box">
+                                1
+                            </div>
+                            <div class="c-arrange__item c-fixture-box">
+                                2
+                            </div>
+                            <div class="c-arrange__item c-fixture-box">
+                                3
+                            </div>
+                        </div>
+                    </div>
+                    <div class="c-arrange__item c-fixture-box">
+                        2
+                    </div>
+                </div>
+
+            </div>
+        </div>
     </article>
 
     <article class="c-test">


### PR DESCRIPTION
Fixes #61.

In iOS 5 and 6, when the Arrange component is used at any nesting level within any flexbox that has `flex-direction` set to `row-reverse` the Arrange component inherits the reversed direction. This [shouldn’t happen](http://www.w3.org/TR/css3-flexbox/).

Status: **Ready to merge**
Reviewers: @jeffkamo @mlworks

## Changes
- Declares `flex-direction: row` on the Arrange root selector

## Todo

- [x] Review tests