### PR TITLE
icon min-width changed to 0

### DIFF
--- a/dist/components/icon/_icon.scss
+++ b/dist/components/icon/_icon.scss
@@ -45,7 +45,7 @@
 [data-icon-name] {
     @include icon-font;
 
-    min-width: 1px; // 1
+    min-width: 0; // 1
 }
 
 

--- a/tests/visual/components/icon/icon.css
+++ b/tests/visual/components/icon/icon.css
@@ -307,6 +307,10 @@ th {
   font-style: normal;
   src: url("../../../../bower_components/spline/test/fixtures/fonts/icon/spline.woff") format("woff"), url("../../../../bower_components/spline/test/fixtures/fonts/icon/spline.ttf") format("truetype"), url("../../../../bower_components/spline/test/fixtures/fonts/icon/spline.svg") format("svg");
 }
+.c-icon,
+[data-icon-name] {
+  min-width: 0;
+}
 .c-icon::before,
 [data-icon-name]::before {
   display: inline-block;


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @jeffkamo @avelinet @cole-sanderson @kpeatt @ry5n @mlworks 

## Changes
- Min-width set to 0 as per [Issue-127](https://github.com/mobify/stencil/issues/127)

## Todos:
- [x] +1
- [x] +1

## Notes:
- Tested on Mrs Norris (4S-iOS 6.1.3)