### PR TITLE
Colour utility

### DIFF
--- a/dist/utils/text/_text.scss
+++ b/dist/utils/text/_text.scss
@@ -1,6 +1,10 @@
 // Text utils
 // ===
 
+$text__accent: if(variable-exists(accent-colot), $accent-color, blue) !default;
+$text__success: if(variable-exists(success-color), $success-color, green) !default;
+$text__error: if(variable-exists(error-color), $error-color, red) !default;
+
 
 // All Caps
 // ---
@@ -49,4 +53,25 @@
 .u-align-baseline,
 %u-align-baseline {
     vertical-align: baseline !important;
+}
+
+
+// Colour accents
+// ---
+//
+// When we need to mark text with colour
+
+.u-text-accent,
+%u-text-accent {
+    color: $text__accent;
+}
+
+.u-text-success,
+%u-text-success {
+    color: $text__success;
+}
+
+.u-text-error,
+%u-text-error {
+    color: $text__error;
 }

--- a/dist/utils/text/_text.scss
+++ b/dist/utils/text/_text.scss
@@ -1,8 +1,8 @@
 // Text utils
 // ===
 
-$text__success: if(variable-exists(success-color), $success-color, green) !default;
-$text__error: if(variable-exists(error-color), $error-color, red) !default;
+$u-text__success: if(variable-exists(success-color), $success-color, green) !default;
+$u-text__error: if(variable-exists(error-color), $error-color, red) !default;
 
 
 // All Caps
@@ -62,10 +62,10 @@ $text__error: if(variable-exists(error-color), $error-color, red) !default;
 
 .u-text-success,
 %u-text-success {
-    color: $text__success;
+    color: $u-text__success;
 }
 
 .u-text-error,
 %u-text-error {
-    color: $text__error;
+    color: $u-text__error;
 }

--- a/dist/utils/text/_text.scss
+++ b/dist/utils/text/_text.scss
@@ -1,7 +1,6 @@
 // Text utils
 // ===
 
-$text__accent: if(variable-exists(accent-color), $accent-color, blue) !default;
 $text__success: if(variable-exists(success-color), $success-color, green) !default;
 $text__error: if(variable-exists(error-color), $error-color, red) !default;
 
@@ -60,11 +59,6 @@ $text__error: if(variable-exists(error-color), $error-color, red) !default;
 // ---
 //
 // When we need to mark text with colour
-
-.u-text-accent,
-%u-text-accent {
-    color: $text__accent;
-}
 
 .u-text-success,
 %u-text-success {

--- a/dist/utils/text/_text.scss
+++ b/dist/utils/text/_text.scss
@@ -1,7 +1,7 @@
 // Text utils
 // ===
 
-$text__accent: if(variable-exists(accent-colot), $accent-color, blue) !default;
+$text__accent: if(variable-exists(accent-color), $accent-color, blue) !default;
 $text__success: if(variable-exists(success-color), $success-color, green) !default;
 $text__error: if(variable-exists(error-color), $error-color, red) !default;
 

--- a/tests/fixtures/fixture.css
+++ b/tests/fixtures/fixture.css
@@ -1,8 +1,8 @@
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 /**
  * 1. Set default font family to sans-serif.
- * 2. Prevent iOS and IE text size adjust after device orientation change,
- *    without disabling user zoom.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
  */
 html {
   font-family: sans-serif;
@@ -69,7 +69,7 @@ audio:not([controls]) {
 
 /*
  * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
  */
 [hidden],
 template {
@@ -86,8 +86,7 @@ a {
 }
 
 /**
- * Improve readability of focused elements when they are also in an
- * active/hover state.
+ * Improve readability when focused and also mouse hovered in all browsers.
  */
 a:active,
 a:hover {
@@ -326,14 +325,15 @@ input[type="number"]::-webkit-outer-spin-button {
 
 /**
  * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
  */
 input[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
   -webkit-box-sizing: content-box;
-          box-sizing: content-box;
   /* 2 */
+  box-sizing: content-box;
 }
 
 /**
@@ -403,7 +403,7 @@ td {
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -449,7 +449,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -461,8 +461,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -472,15 +472,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -495,7 +495,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -522,12 +522,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -545,7 +563,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -566,20 +584,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -590,22 +607,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -625,13 +642,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -641,16 +658,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -662,12 +696,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -677,19 +711,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -705,19 +739,19 @@ th {
   font-style: normal;
 }
 .c-test {
-  margin-right: -15.75px;
-  margin-left: -15.75px;
+  margin-right: -15px;
+  margin-left: -15px;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 3px;
 }
 
 .c-test + .c-test {
-  margin-top: 16.5px;
+  margin-top: 15px;
 }
 
 .c-test__describe {
   margin: 0;
-  padding: 5.5px 15.75px;
+  padding: 5px 15px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
 
@@ -727,14 +761,14 @@ th {
 
 .c-test__should {
   margin: 0;
-  padding: 5.5px 15.75px;
+  padding: 5px 15px;
   font-weight: bold;
 }
 
 .c-test__a-b {
   table-layout: fixed;
   width: 100%;
-  margin-top: 2.75px;
+  margin-top: 2.5px;
   font-size: 0.9em;
 }
 .c-test__a-b th {
@@ -749,7 +783,7 @@ th {
 
 .c-test__run {
   margin: 0;
-  padding: 15.75px;
+  padding: 15px;
   background: whitesmoke;
   color: #737373;
 }

--- a/tests/visual/components/alert/alert.css
+++ b/tests/visual/components/alert/alert.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -301,10 +335,10 @@ th {
 }
 
 .c-alert {
-  padding: 11px 21px;
+  padding: 10px 20px;
   border-width: 1px;
   border-style: solid;
-  border-color: #bdc3c7;
+  border-color: #BBB;
 }
 .c-alert > *:last-child {
   margin-bottom: 0;

--- a/tests/visual/components/arrange/arrange.css
+++ b/tests/visual/components/arrange/arrange.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -419,10 +453,10 @@ th {
 }
 
 .c-arrange.c--gutters {
-  margin-right: -10.5px;
-  margin-left: -10.5px;
+  margin-right: -10px;
+  margin-left: -10px;
 }
 
 .c-arrange.c--gutters > .c-arrange__item {
-  margin: 0 10.5px;
+  margin: 0 10px;
 }

--- a/tests/visual/components/arrange/arrange.css
+++ b/tests/visual/components/arrange/arrange.css
@@ -304,6 +304,10 @@ th {
   display: -webkit-box;
   display: -webkit-flex;
   display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+          flex-direction: row;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -405,6 +409,13 @@ th {
   -webkit-box-ordinal-group: 7;
   -webkit-order: 6;
           order: 6;
+}
+
+.c-arrange.c--row-reverse {
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: reverse;
+  -webkit-flex-direction: row-reverse;
+          flex-direction: row-reverse;
 }
 
 .c-arrange.c--gutters {

--- a/tests/visual/components/breadcrumb/breadcrumb.css
+++ b/tests/visual/components/breadcrumb/breadcrumb.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,

--- a/tests/visual/components/button/button.css
+++ b/tests/visual/components/button/button.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -304,7 +338,7 @@ th {
   display: inline-block;
   margin: 0;
   padding: 0.5rem 0.75rem;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background: none;
   font-family: inherit;

--- a/tests/visual/components/grid/grid.css
+++ b/tests/visual/components/grid/grid.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -363,13 +397,13 @@ th {
 }
 
 .c-grid.c--gutters {
-  margin-right: -5.5px;
-  margin-left: -5.5px;
+  margin-right: -5px;
+  margin-left: -5px;
 }
 .c-grid.c--gutters:before {
-  margin-top: -11px;
+  margin-top: -10px;
 }
 
 .c-grid.c--gutters > .c-grid__span {
-  padding: 11px 5.5px 0;
+  padding: 10px 5px 0;
 }

--- a/tests/visual/components/icon/icon.css
+++ b/tests/visual/components/icon/icon.css
@@ -6,7 +6,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -52,7 +52,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -64,8 +64,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -75,15 +75,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -98,7 +98,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -125,12 +125,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -148,7 +166,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -169,20 +187,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -193,22 +210,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -228,13 +245,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -244,16 +261,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -265,12 +299,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -280,19 +314,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,

--- a/tests/visual/components/media/media.css
+++ b/tests/visual/components/media/media.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -310,7 +344,7 @@ th {
 }
 
 .c-media__figure {
-  margin-right: 21px;
+  margin-right: 20px;
 }
 
 .c-media__body {
@@ -330,5 +364,5 @@ th {
   -webkit-order: 1;
           order: 1;
   margin-right: 0;
-  margin-left: 21px;
+  margin-left: 20px;
 }

--- a/tests/visual/components/ratio/ratio.css
+++ b/tests/visual/components/ratio/ratio.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,

--- a/tests/visual/components/select/select.css
+++ b/tests/visual/components/select/select.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -313,8 +347,8 @@ th {
           box-sizing: border-box;
   max-width: 100%;
   height: 3rem;
-  padding: 11px 21px;
-  border: 1px solid #bdc3c7;
+  padding: 10px 20px;
+  border: 1px solid #BBB;
   border-radius: 0;
   font-family: inherit;
   font-size: inherit;
@@ -327,7 +361,7 @@ th {
   left: 0;
   width: 100%;
   height: 100%;
-  padding: 11px 21px;
+  padding: 10px 20px;
   border: 0;
   background: none;
   -webkit-appearance: none;
@@ -342,7 +376,7 @@ th {
   content: '';
   position: absolute;
   top: 0;
-  right: 21px;
+  right: 20px;
   bottom: 0;
   margin: auto;
 }

--- a/tests/visual/components/spinner/spinner.css
+++ b/tests/visual/components/spinner/spinner.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,

--- a/tests/visual/components/stack/stack.css
+++ b/tests/visual/components/stack/stack.css
@@ -5,7 +5,7 @@
 
 html {
   background: white;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -51,7 +51,7 @@ h6 {
 }
 
 p {
-  margin: 0 0 11px;
+  margin: 0 0 10px;
 }
 
 a {
@@ -63,8 +63,8 @@ a:active, a:focus {
 }
 
 hr {
-  margin: 22px 0;
-  border: 1px solid #bdc3c7;
+  margin: 20px 0;
+  border: 1px solid #BBB;
   border-width: 0 0 1px;
 }
 
@@ -74,15 +74,15 @@ img {
 }
 
 blockquote {
-  margin: 22px 0;
-  padding-left: 21px;
-  border-left: 2px solid #bdc3c7;
-  color: #585f61;
+  margin: 20px 0;
+  padding-left: 10px;
+  border-left: 2px solid #BBB;
+  color: #595959;
 }
 
 fieldset {
   min-width: 0;
-  margin: 0 0 11px;
+  margin: 0 0 10px;
   padding: 0;
   border: 0;
 }
@@ -97,7 +97,7 @@ select {
 }
 
 label {
-  margin-bottom: 5.5px;
+  margin-bottom: 5px;
   font-weight: bold;
   -webkit-tap-highlight-color: transparent;
 }
@@ -124,12 +124,30 @@ textarea,
   width: 100%;
   height: 40px;
   padding: 10px 15px;
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
   border-radius: 4px;
   background-color: #fff;
   line-height: 21px;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
+}
+select::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder,
+[type="text"]::-webkit-input-placeholder,
+[type="search"]::-webkit-input-placeholder,
+[type="password"]::-webkit-input-placeholder,
+[type="datetime"]::-webkit-input-placeholder,
+[type="datetime-local"]::-webkit-input-placeholder,
+[type="date"]::-webkit-input-placeholder,
+[type="month"]::-webkit-input-placeholder,
+[type="time"]::-webkit-input-placeholder,
+[type="week"]::-webkit-input-placeholder,
+[type="number"]::-webkit-input-placeholder,
+[type="email"]::-webkit-input-placeholder,
+[type="url"]::-webkit-input-placeholder,
+[type="tel"]::-webkit-input-placeholder,
+[type="color"]::-webkit-input-placeholder {
+  color: #888;
 }
 select:active,
 textarea:active,
@@ -147,7 +165,7 @@ textarea:active,
 [type="url"]:active,
 [type="tel"]:active,
 [type="color"]:active {
-  border-color: #a1aab0;
+  border-color: #a2a2a2;
 }
 select:focus,
 textarea:focus,
@@ -168,20 +186,19 @@ textarea:focus,
   border-color: #16a085;
 }
 
+textarea {
+  height: auto;
+}
+
 input[type="search"] {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   -webkit-appearance: none;
 }
 
-textarea {
-  height: auto;
-}
-
 select {
   padding: 8px 15px;
-  border-color: #bcc2c6;
-  text-indent: 5px;
+  border-color: #bababa;
   -webkit-appearance: menulist-button;
 }
 
@@ -192,22 +209,22 @@ select {
   display: inline-block;
   width: 24px;
   height: 24px;
-  margin-right: 10.5px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  margin-right: 10px;
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   vertical-align: middle;
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 [type="checkbox"]:active,
 [type="radio"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
 }
 [type="checkbox"]:checked,
 [type="radio"]:checked {
-  background: #ecf0f1;
+  background: #E8E8E8;
   -webkit-box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
           box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -227,13 +244,13 @@ select {
   bottom: 20%;
   left: 20%;
   border-radius: 24px;
-  background: #343839;
+  background: #333;
 }
 
 [type="checkbox"]:checked:after {
   content: '\2714';
   top: 0;
-  color: #343839;
+  color: #333;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 32px;
   line-height: 14px;
@@ -243,16 +260,33 @@ button,
 [type="submit"] {
   display: block;
   padding: 10px 15px;
-  border: 1px solid #bcc2c6;
-  background: #ecf0f1 -webkit-gradient(linear, left top, left bottom, from(white), to(#ecf0f1));
-  background: #ecf0f1 -webkit-linear-gradient(white, #ecf0f1);
-  background: #ecf0f1 linear-gradient(white, #ecf0f1);
+  border: 1px solid #bababa;
+  background: #E8E8E8 -webkit-gradient(linear, left top, left bottom, from(white), to(#E8E8E8));
+  background: #E8E8E8 -webkit-linear-gradient(white, #E8E8E8);
+  background: #E8E8E8 linear-gradient(white, #E8E8E8);
   -webkit-tap-highlight-color: transparent;
   -webkit-appearance: none;
 }
 button:active,
 [type="submit"]:active {
-  background: #bdc3c7 reverse-gradient(linear-gradient(white, #ecf0f1));
+  background: #BBB reverse-gradient(linear-gradient(white, #E8E8E8));
+}
+
+[disabled] {
+  opacity: 1;
+  background: #E8E8E8;
+  color: #BBB;
+  -webkit-text-fill-color: #BBB;
+}
+[disabled]:active, [disabled]:checked {
+  border-color: #BBB;
+  background: #E8E8E8;
+}
+[disabled]:active::after, [disabled]:checked::after {
+  color: #BBB;
+}
+[disabled][type="radio"]:after {
+  background-color: #BBB;
 }
 
 ul,
@@ -264,12 +298,12 @@ ol {
 
 dl {
   line-height: 21px;
-  margin-bottom: 11px;
+  margin-bottom: 10px;
 }
 
 dt {
   font-weight: bold;
-  margin-top: 11px;
+  margin-top: 10px;
 }
 
 dd {
@@ -279,19 +313,19 @@ dd {
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: 11px 0;
+  margin: 10px 0;
 }
 
 th {
-  padding: 11px 0;
-  border-bottom: 1px solid #949da4;
+  padding: 10px 0;
+  border-bottom: 1px solid #959595;
   font-weight: bold;
   text-align: left;
 }
 
 td {
-  padding: 11px 0;
-  border-bottom: 1px solid #bdc3c7;
+  padding: 10px 0;
+  border-bottom: 1px solid #BBB;
 }
 
 tr,
@@ -308,8 +342,8 @@ th {
 
 .c-stack__item {
   display: block;
-  padding-top: 11px;
-  padding-bottom: 11px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 .c-stack__item:first-child {
   padding-top: 0;
@@ -319,16 +353,16 @@ th {
 }
 
 .c-stack.c--ruled > .c-stack__item {
-  border-top: 1px solid #bdc3c7;
+  border-top: 1px solid #BBB;
 }
 .c-stack.c--ruled > .c-stack__item:first-child {
   border-top-width: 0;
 }
 
 .c-stack.c--bordered {
-  border: 1px solid #bdc3c7;
+  border: 1px solid #BBB;
 }
 
 .c-stack.c--bordered > .c-stack__item {
-  padding: 11px;
+  padding: 10px;
 }

--- a/tests/visual/utils/text/index.html
+++ b/tests/visual/utils/text/index.html
@@ -84,5 +84,27 @@
             </div>
         </div>
     </article>
+
+    <article class="c-test">
+        <h2 class="c-test__describe">u-text-success</h2>
+
+        <div class="c-test__case">
+            <p class="c-test__should">There should be text with success colour:</p>
+            <div class="c-test__run">
+                <p class="u-text-success">I should have success colour</p>
+            </div>
+        </div>
+    </article>
+
+    <article class="c-test">
+        <h2 class="c-test__describe">u-text-error</h2>
+
+        <div class="c-test__case">
+            <p class="c-test__should">There should be text with error colour:</p>
+            <div class="c-test__run">
+                <p class="u-text-error">I should have error colour</p>
+            </div>
+        </div>
+    </article>
 </body>
 </html>

--- a/tests/visual/utils/text/text.css
+++ b/tests/visual/utils/text/text.css
@@ -22,3 +22,15 @@
 .u-align-baseline {
   vertical-align: baseline !important;
 }
+
+.u-text-accent {
+  color: blue;
+}
+
+.u-text-success {
+  color: green;
+}
+
+.u-text-error {
+  color: red;
+}

--- a/tests/visual/utils/text/text.css
+++ b/tests/visual/utils/text/text.css
@@ -23,10 +23,6 @@
   vertical-align: baseline !important;
 }
 
-.u-text-accent {
-  color: blue;
-}
-
 .u-text-success {
   color: green;
 }


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @ry5n @kpeatt @avelinet @cole-sanderson @yourpalsonja @jeffkamo @mlworks 

## Changes
`u-text-accent`, `u-text-success` and `u-text-error` utilities added to `_text.scss`

## Proof of existence 
Sometimes we need to add just text colour to a word. With component approach we don't have many template files and sometimes we create them for just one line. This is where colour utility could help us.

I couldn't find a way to avoid using `$text__accent` variables. Is there a way to use Vellum variables without it?

## Todos:
- [x] Designer +1 (@jeffkamo)
- [x] Designer +1 (@ry5n)